### PR TITLE
Add aws session token

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -96,6 +96,7 @@ return [
             'credentials' => [
                 'key'     => env('AWS_ACCESS_KEY_ID', ''),
                 'secret'  => env('AWS_SECRET_ACCESS_KEY', ''),
+                'token'   => env('AWS_SESSION_TOKEN', ''),
             ],
 
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),

--- a/src/TextToSpeechManager.php
+++ b/src/TextToSpeechManager.php
@@ -66,7 +66,7 @@ class TextToSpeechManager extends Manager
      */
     protected function getCredentials(array $credentials)
     {
-        return new Credentials($credentials['key'], $credentials['secret']);
+        return new Credentials($credentials['key'], $credentials['secret'], $credentials['token']);
     }
 
     /**


### PR DESCRIPTION
Hello,
Many thanks for this OS package!

I'm using it in a project deployed on AWS Lambda (Bref + Serverless framework), locally with Sail it worked but when deploying it on AWS I was getting:

```
Aws\Polly\Exception\PollyException
Error executing "SynthesizeSpeech" on "https://polly.eu-central-1.amazonaws.com/v1/speech"; AWS HTTP error: Client error: `POST https://polly.eu-central-1.amazonaws.com/v1/speech` resulted in a `403 Forbidden` response:
{"message":"The security token included in the request is invalid."}
 UnrecognizedClientException (client): The security token included in the request is invalid. - {"message":"The security token included in the request is invalid."}
```

I've added the `AWS_SESSION_TOKEN` config field which allows the AWS SDK to work even when using an assumed IAM role.